### PR TITLE
Fix build errors for Alibaba Cloud deployment

### DIFF
--- a/app/components/message-selector.tsx
+++ b/app/components/message-selector.tsx
@@ -191,7 +191,7 @@ export function MessageSelector(props: {
       <div className={styles["messages"]}>
         {messages.map((m, i) => {
           if (!isInSearchResult(m.id!)) return null;
-          const id = m.id ?? i;
+          const id = m.id ?? String(i);
           const isSelected = props.selection.has(id);
 
           return (

--- a/app/mcp/client.ts
+++ b/app/mcp/client.ts
@@ -44,7 +44,7 @@ export async function removeClient(client: Client) {
 }
 
 export async function listTools(client: Client): Promise<ListToolsResponse> {
-  return client.listTools();
+  return client.listTools() as unknown as ListToolsResponse;
 }
 
 export async function executeRequest(

--- a/app/mcp/types.ts
+++ b/app/mcp/types.ts
@@ -12,12 +12,12 @@ export interface McpRequestMessage {
   };
 }
 
-export const McpRequestMessageSchema: z.ZodType<McpRequestMessage> = z.object({
+export const McpRequestMessageSchema = z.object({
   jsonrpc: z.literal("2.0").optional(),
   id: z.union([z.string(), z.number()]).optional(),
   method: z.string(),
   params: z.record(z.unknown()).optional(),
-});
+}) as z.ZodType<McpRequestMessage>;
 
 export interface McpResponseMessage {
   jsonrpc?: "2.0";
@@ -32,20 +32,18 @@ export interface McpResponseMessage {
   };
 }
 
-export const McpResponseMessageSchema: z.ZodType<McpResponseMessage> = z.object(
-  {
-    jsonrpc: z.literal("2.0").optional(),
-    id: z.union([z.string(), z.number()]).optional(),
-    result: z.record(z.unknown()).optional(),
-    error: z
-      .object({
-        code: z.number(),
-        message: z.string(),
-        data: z.unknown().optional(),
-      })
-      .optional(),
-  },
-);
+export const McpResponseMessageSchema = z.object({
+  jsonrpc: z.literal("2.0").optional(),
+  id: z.union([z.string(), z.number()]).optional(),
+  result: z.record(z.unknown()).optional(),
+  error: z
+    .object({
+      code: z.number(),
+      message: z.string(),
+      data: z.unknown().optional(),
+    })
+    .optional(),
+}) as z.ZodType<McpResponseMessage>;
 
 export interface McpNotifications {
   jsonrpc?: "2.0";
@@ -55,11 +53,11 @@ export interface McpNotifications {
   };
 }
 
-export const McpNotificationsSchema: z.ZodType<McpNotifications> = z.object({
+export const McpNotificationsSchema = z.object({
   jsonrpc: z.literal("2.0").optional(),
   method: z.string(),
   params: z.record(z.unknown()).optional(),
-});
+}) as z.ZodType<McpNotifications>;
 
 ////////////
 // Next Chat

--- a/app/store/prompt.ts
+++ b/app/store/prompt.ts
@@ -112,6 +112,7 @@ export const usePromptStore = createPersistStore(
         title: "",
         content: "",
         id,
+        createdAt: Date.now(),
       };
 
       SearchService.remove(id);


### PR DESCRIPTION
## Summary
- make message selector id always a string
- cast MCP client listTools to expected type
- adjust Zod schemas to satisfy typings
- ensure prompts have `createdAt` when created

## Testing
- `yarn lint`
- `yarn test -o`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_685fc37910c08321805f4da344c9ed83