### PR TITLE
Enable realtime chat UI by default

### DIFF
--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -56,7 +56,7 @@ const config = getClientConfig();
 const serverRealtimeConfig = config?.realtimeConfig;
 
 const defaultRealtimeConfig: IRealtimeConfig = {
-  enable: serverRealtimeConfig?.enabled ?? false,
+  enable: serverRealtimeConfig?.enabled ?? true,
   provider: (serverRealtimeConfig?.provider ?? "OpenAI") as ServiceProvider,
   model: serverRealtimeConfig?.model ?? "gpt-4o-realtime-preview-2024-10-01",
   apiKey: serverRealtimeConfig?.apiKey ?? "", // Note: This key is read from server config and will be persisted in local storage.


### PR DESCRIPTION
## Summary
- enable realtime chat button by default

## Testing
- `yarn test:ci` *(fails: couldn't find jest)*

------
https://chatgpt.com/codex/tasks/task_e_68603ca2111c8321a37d3cf1e94295a3