### PR TITLE
Enable realtime chat by default

### DIFF
--- a/app/components/realtime-chat/realtime-chat.tsx
+++ b/app/components/realtime-chat/realtime-chat.tsx
@@ -87,10 +87,10 @@ export function RealtimeChat({
         ? BUILTIN_MASK_STORE.get(mask.id)?.context
         : [];
       const contextPrompts = mask.context ?? [];
-      const systemPrompts = builtinPrompts
-        ?.concat(contextPrompts)
-        .filter((p) => p.role === "system");
-      const instructions = systemPrompts.map((p) => p.content).join("\n\n");
+
+      // Combine all prompts so the realtime session has the same context as text chat
+      const allPrompts = builtinPrompts.concat(contextPrompts);
+      const instructions = allPrompts.map((p) => p.content).join("\n\n");
 
       if (instructions) {
         await clientRef.current.updateSession({

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -56,7 +56,7 @@ const config = getClientConfig();
 const serverRealtimeConfig = config?.realtimeConfig;
 
 const defaultRealtimeConfig: IRealtimeConfig = {
-  enable: serverRealtimeConfig?.enabled ?? false,
+  enable: serverRealtimeConfig?.enabled ?? true,
   provider: (serverRealtimeConfig?.provider ?? "OpenAI") as ServiceProvider,
   model: serverRealtimeConfig?.model ?? "gpt-4o-realtime-preview-2024-10-01",
   apiKey: serverRealtimeConfig?.apiKey ?? "", // Note: This key is read from server config and will be persisted in local storage.


### PR DESCRIPTION
## Summary
- enable realtime chat by default
- sync realtime prompts with full mask context

## Testing
- `yarn lint`
- `yarn test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68603ca2111c8321a37d3cf1e94295a3